### PR TITLE
Fix type conversion issues with some Django field types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cci-src"]
 	path = cci-src
-	url = git@github.com:CUBRID/cubrid-cci.git
+	url = https://github.com/CUBRID/cubrid-cci.git

--- a/CUBRIDdb/cursors.py
+++ b/CUBRIDdb/cursors.py
@@ -7,7 +7,7 @@ class BaseCursor(object):
     A base for Cursor classes. Useful attributes:
 
     description::
-        A tuple of DB API 7-tuples describing the columns in 
+        A tuple of DB API 7-tuples describing the columns in
         the last executed query; see PEP-249 for details.
 
     arraysize::
@@ -138,7 +138,10 @@ class BaseCursor(object):
 
     def _fetch_row(self):
         self.__check_state()
-        return self._cs.fetch_row(self._fetch_type)
+        row = self._cs.fetch_row(self._fetch_type)
+        if row is not None and self._fetch_type == 0:
+            return tuple(row)
+        return row
 
     def fetchone(self):
         """

--- a/django_cubrid/base.py
+++ b/django_cubrid/base.py
@@ -392,16 +392,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'regex': 'REGEXP BINARY %s',
         'iregex': 'REGEXP %s',
     }
-    # Patterns taken from PosgreSQL implementation.
+    # Patterns taken from other backend implementations.
     # The patterns below are used to generate SQL pattern lookup clauses when
     # the right-hand side of the lookup isn't a raw string (it might be an expression
     # or the result of a bilateral transformation).
     # In those cases, special characters for LIKE operators (e.g. \, *, _) should be
     # escaped on database side.
-    #
-    # Note: we use str.format() here for readability as '%' is used as a wildcard for
-    # the LIKE operator.
-    pattern_esc = r"REPLACE(REPLACE(REPLACE({}, '\', '\\'), '%%', '\%%'), '_', '\_')"
+    pattern_esc = r"REPLACE(REPLACE(REPLACE({}, '\\', '\\\\'), '%%', '\%%'), '_', '\_')"
     pattern_ops = {
         'contains': "LIKE '%%' || {} || '%%'",
         'icontains': "LIKE '%%' || UPPER({}) || '%%'",

--- a/django_cubrid/base.py
+++ b/django_cubrid/base.py
@@ -7,6 +7,7 @@ Requires CUBRIDdb: http://www.cubrid.org/wiki_apis
 import re
 import sys
 import django
+import uuid
 import warnings
 
 try:
@@ -25,6 +26,7 @@ from django_cubrid.creation import DatabaseCreation
 from django_cubrid.introspection import DatabaseIntrospection
 from django_cubrid.validation import DatabaseValidation
 from django.utils import timezone
+from django.utils.encoding import force_text
 from django.conf import settings
 if django.VERSION >= (1, 7) and django.VERSION < (1, 8):
     from django_cubrid.schema import DatabaseSchemaEditor
@@ -340,13 +342,35 @@ class DatabaseOperations(BaseDatabaseOperations):
     def get_db_converters(self, expression):
         converters = super().get_db_converters(expression)
         internal_type = expression.output_field.get_internal_type()
-        if internal_type in ["BooleanField", "NullBooleanField"]:
+        if internal_type == 'TextField':
+            converters.append(self.convert_textfield_value)
+        elif internal_type in ['BooleanField', 'NullBooleanField']:
             converters.append(self.convert_booleanfield_value)
+        elif internal_type == 'DateTimeField':
+            if settings.USE_TZ:
+                converters.append(self.convert_datetimefield_value)
+        elif internal_type == 'UUIDField':
+            converters.append(self.convert_uuidfield_value)
         return converters
+
+    def convert_textfield_value(self, value, expression, connection):
+        if value is not None:
+            value = force_text(value)
+        return value
 
     def convert_booleanfield_value(self, value, expression, connection):
         if value in (0, 1):
             value = bool(value)
+        return value
+
+    def convert_datetimefield_value(self, value, expression, connection):
+        if value is not None:
+            value = timezone.make_aware(value, self.connection.timezone)
+        return value
+
+    def convert_uuidfield_value(self, value, expression, connection):
+        if value is not None:
+            value = uuid.UUID(value)
         return value
 
 
@@ -484,7 +508,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         url += ':::'
 
         con = Database.connect(url, user, passwd, charset='utf8')
-        con.set_fetch_value_converter(django_fetch_value_converter)
 
         return con
 
@@ -534,16 +557,3 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             return DatabaseSchemaEditor(self, *args, **kwargs)
 
 
-def django_fetch_value_converter(row, descriptor):
-    # We need to convert naive datetime values to aware, if USE_TZ is true.
-    if not settings.USE_TZ:
-        return row
-
-    index = 0
-    for des in descriptor:
-        if des[1] == FIELD_TYPE.DATETIME and timezone.is_naive(row[index]):
-            row[index] = row[index].replace(tzinfo=timezone.utc)
-
-        index = index + 1
-
-    return row

--- a/django_cubrid/base.py
+++ b/django_cubrid/base.py
@@ -234,7 +234,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         return "DROP FOREIGN KEY"
 
     def force_no_ordering(self):
-        return ["NULL"]
+        return [(None, ("NULL", [], False))]
 
     def fulltext_search_sql(self, field_name):
         return 'MATCH (%s) AGAINST (%%s IN BOOLEAN MODE)' % field_name

--- a/django_cubrid/base.py
+++ b/django_cubrid/base.py
@@ -441,6 +441,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             'UUIDField': 'char(32)',
         }
         SchemaEditorClass = DatabaseSchemaEditor
+    if django.VERSION >= (1, 10):
+        _data_types.update({
+            'BigAutoField': 'bigint AUTO_INCREMENT',
+        })
 
     if django.VERSION >= (1, 11):
         client_class = DatabaseClient

--- a/django_cubrid/base.py
+++ b/django_cubrid/base.py
@@ -191,20 +191,18 @@ class DatabaseOperations(BaseDatabaseOperations):
                 warnings.warn("CUBRID does not support timezone conversion",
                               RuntimeWarning)
 
-        params = []
         if lookup_type == 'week_day':
             # DAYOFWEEK() returns an integer, 1-7, Sunday=1.
             # Note: WEEKDAY() returns 0-6, Monday=0.
-            return "DAYOFWEEK(%s)" % field_name, params
+            return "DAYOFWEEK(%s)" % field_name
         else:
-            return "EXTRACT(%s FROM %s)" % (lookup_type.upper(), field_name), params
+            return "EXTRACT(%s FROM %s)" % (lookup_type.upper(), field_name)
 
     def datetime_trunc_sql(self, lookup_type, field_name, tzname):
         if settings.USE_TZ:
                 warnings.warn("CUBRID does not support timezone conversion",
                               RuntimeWarning)
 
-        params = []
         fields = ['year', 'month', 'day', 'hour', 'minute', 'second', 'milisecond']
         # Use double percents to escape.
         format = ('%%Y-', '%%m', '-%%d', ' %%H:', '%%i', ':%%s', '.%%ms')
@@ -216,7 +214,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         else:
             format_str = ''.join([f for f in format[:i]] + [f for f in format_def[i:]])
             sql = "CAST(DATE_FORMAT(%s, '%s') AS DATETIME)" % (field_name, format_str)
-        return sql, params
+        return sql
 
     def date_interval_sql(self, sql, connector, timedelta):
         if connector.strip() == '+':

--- a/django_cubrid/base.py
+++ b/django_cubrid/base.py
@@ -111,6 +111,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     # CUBRID 9.3 can't retrieve foreign key info from catalog tables.
     can_introspect_foreign_keys = False
 
+    can_introspect_small_integer_field = True
+
     can_return_id_from_insert = False
 
     can_rollback_ddl = True

--- a/django_cubrid/creation.py
+++ b/django_cubrid/creation.py
@@ -147,19 +147,6 @@ class DatabaseCreation(BaseDatabaseCreation):
         self.connection._commit()
         return count == 0
 
-    def destroy_test_db(self, old_database_name, verbosity=1):
-        """
-        Destroy a test database, prompting the user for confirmation if the
-        database already exists. Returns the name of the test database created.
-        """
-        if verbosity >= 1:
-            print("Destroying test database '%s'..." % self.connection.alias)
-        self.connection.close()
-        test_database_name = self.connection.settings_dict['NAME']
-        self.connection.settings_dict['NAME'] = old_database_name
-
-        self._destroy_test_db(test_database_name, verbosity)
-
     def _destroy_test_db(self, test_database_name, verbosity):
         "Internal implementation - remove the test db tables."
         # Remove the test database to clean up after
@@ -167,7 +154,6 @@ class DatabaseCreation(BaseDatabaseCreation):
         # to do so, because it's not allowed to delete a database while being
         # connected to it.
         cursor = self.connection.cursor()
-        self.set_autocommit()
         time.sleep(1) # To avoid "database is being accessed by other users" errors.
         p = subprocess.Popen(["cubrid", "server", "stop", test_database_name])
         ret = os.waitpid(p.pid, 0)[1]

--- a/django_cubrid/creation.py
+++ b/django_cubrid/creation.py
@@ -91,7 +91,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         if keepdb:
             # Check if the test database already exists, in case keepdb is True
             try:
-                subprocess.run(check_command, check = True)
+                subprocess.check_call(check_command)
                 return # nothing to do if it already exists
             except subprocess.CalledProcessError:
                 pass # go ahead and create it
@@ -106,10 +106,11 @@ class DatabaseCreation(BaseDatabaseCreation):
             pass
 
         try:
-            subprocess.call(create_command)
+            subprocess.check_call(create_command)
             print('Created')
-            subprocess.call(start_command)
+            subprocess.check_call(start_command)
             print('Started')
+            subprocess.check_call(check_command)
 
         except Exception as e:
             sys.stderr.write("Got an error creating the test database: %s\n" % e)
@@ -119,12 +120,12 @@ class DatabaseCreation(BaseDatabaseCreation):
                 try:
                     if verbosity >= 1:
                         print("Destroying old test database...")
-                        subprocess.call(stop_command)
-                        subprocess.call(delete_command)
+                        subprocess.check_call(stop_command)
+                        subprocess.check_call(delete_command)
 
                         print("Creating test database...")
-                        subprocess.call(create_command)
-                        subprocess.call(start_command)
+                        subprocess.check_call(create_command)
+                        subprocess.check_call(start_command)
                 except Exception as e:
                     sys.stderr.write("Got an error recreating the test database: %s\n" % e)
                     sys.exit(2)

--- a/django_cubrid/schema.py
+++ b/django_cubrid/schema.py
@@ -46,18 +46,18 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         # Work out nullability
         null = field.null
         # If we were told to include a default value, do so
-        default_value = self.effective_default(field)
         include_default = include_default and not self.skip_default(field)
-        if include_default and default_value is not None:
-            if field.get_internal_type() == "BooleanField" and isinstance(default_value, bool):
-                default_value = 1 if default_value else 0
-            if self.connection.features.requires_literal_defaults:
-                # Some databases can't take defaults as a parameter (oracle)
-                # If this is the case, the individual schema backend should
-                # implement prepare_default
-                sql += " DEFAULT %s" % self.prepare_default(default_value)
-            else:
-                sql += " DEFAULT '%s'" % default_value
+        if include_default:
+            default_value = self.effective_default(field)
+            if default_value is not None:
+                if self.connection.features.requires_literal_defaults:
+                    # Some databases can't take defaults as a parameter (oracle)
+                    # If this is the case, the individual schema backend should
+                    # implement prepare_default
+                    sql += " DEFAULT %s" % self.prepare_default(default_value)
+                else:
+                    sql += " DEFAULT %s"
+                    params += [default_value]
         if not field.get_internal_type() in ("BinaryField",):
             # Oracle treats the empty string ('') as null, so coerce the null
             # option whenever '' is a possible value.


### PR DESCRIPTION
Some field types need conversions performed in order to behave as
expected with Django. Including BooleanField, NullBooleanField,
TextField, DateTimeFields, UUIDFields.

There was an older approach to converting the date-time values, but it
is simpler with the new approach.

The new approach is copied from the MySql django backend, which needs
the same conversions.