### PR TITLE
[APIS-807] Rebuild shell script for test2 group

### DIFF
--- a/tests2/init.sh
+++ b/tests2/init.sh
@@ -28,3 +28,11 @@ function check_verdict ()
 	echo $verdict
 }
 
+function python_version_check ()
+{
+	local version=$($1 --version 2>&1)
+	local major=$(echo $version | cut -d ' ' -f2-2)
+	major=${major:0:1}
+
+	echo $major
+}

--- a/tests2/init.sh
+++ b/tests2/init.sh
@@ -1,0 +1,30 @@
+# supplmentatry functions for python test
+
+
+function find_python ()
+{
+        arg=$(echo $* | cut -d'=' -f1-1)
+        if [ x$arg = "xpython" ];then
+                arg=$(echo $* | cut -d'=' -f2-2)
+                echo $arg
+        else
+                echo "python"   # Use default
+        fi
+}
+
+function check_verdict ()
+{
+	if [ ! -f $1 ];then
+		echo "NONE"
+		return
+	fi
+
+	verdict=$(grep FAILED $1)
+	if [ -z "$verdict" ];then
+		verdict="Passed"
+	else
+		verdict=$(echo $verdict | cut -d ':' -f2-2);
+	fi
+	echo $verdict
+}
+

--- a/tests2/python/_05_datetype/DataTypeTest.py
+++ b/tests2/python/_05_datetype/DataTypeTest.py
@@ -240,7 +240,7 @@ class FetchoneTypeTest(unittest.TestCase):
         def test_timestamp(self):
 #               test normal datetime type
                 dataList = ['10/31','10/31/2008','13:15:45 10/31/2008']
-		dataCheck = ['2013-10-31 00:00:00','2008-10-31 00:00:00','2008-10-31 13:15:45']
+		dataCheck = ['2019-10-31 00:00:00','2008-10-31 00:00:00','2008-10-31 13:15:45']
                 sqlInsert = "insert into datetime_db(c_timestamp) values "
                 for i in dataList:
                         sqlInsert = sqlInsert + "('" + i + "'),"

--- a/tests2/python/_05_datetype/DateTime.py
+++ b/tests2/python/_05_datetype/DateTime.py
@@ -148,10 +148,11 @@ class CubridDataTimeTest(unittest.TestCase):
         def test_cubrid_timefromticks(self):
 #               test cubrid timeformticks
                 dataTuple=(0.00,57599.00,57600.00,)
-                dataCheck=[datetime.time(8,0,0),datetime.time(23,59,59),datetime.time(0,0,0)]
+                dataCheck=[datetime.time(9,0,0),datetime.time(0,59,59),datetime.time(1,0,0)]
+                print '-----------------------------------------------------------------------------'
                 for i in range(len(dataTuple)):
                         data = CUBRIDdb.TimeFromTicks(dataTuple[i])
-                        print "cubrid time: ",data
+                        print "cubrid time: ",i, data
                         self.assertEquals(dataCheck[i], data)
 
         def test_cubrid_timefromticks_invalid(self):
@@ -167,8 +168,8 @@ class CubridDataTimeTest(unittest.TestCase):
 
         def test_cubrid_timestampfromticks(self):
 #               test cubrid timeformticks
-                dataTuple=(-1,0.00,57599.00,57600.00,)
-                dataCheck=[datetime.datetime(1970,1,1,7,59,59),datetime.datetime(1970,1,1,8,0,0),datetime.datetime(1970,1,1,23,59,59),datetime.datetime(1970,1,2,0,0,0)]
+                dataTuple=(-1.00,0.00,140399.00,54000.00,)
+                dataCheck=[datetime.datetime(1970,1,1,8,59,59),datetime.datetime(1970,1,1,9,0,0),datetime.datetime(1970,1,2,23,59,59),datetime.datetime(1970,1,2,0,0,0)]
                 for i in range(len(dataTuple)):
                         data = CUBRIDdb.TimestampFromTicks(dataTuple[i])
                         print "cubrid time: ",data

--- a/tests2/python/_05_datetype/InvalidDataTypeTest.py
+++ b/tests2/python/_05_datetype/InvalidDataTypeTest.py
@@ -199,7 +199,7 @@ class InvalidDataTypeTest(unittest.TestCase):
         def test_timestamp(self):
 #               test invalid datetime type
                 dataList = ['10/31','10/31/2008','13:15:45 10/31/2008']
-		dataCheck = ['2013-10-31 00:00:00','2008-10-31 00:00:00','2008-10-31 13:15:45']
+		dataCheck = ['2019-10-31 00:00:00','2008-10-31 00:00:00','2008-10-31 13:15:45']
                 sqlInsert = "insert into datetime_db(c_timestamp) values "
                 for i in dataList:
                         sqlInsert = sqlInsert + "('" + i + "'),"

--- a/tests2/python/_06_description/DescriptionTest.py
+++ b/tests2/python/_06_description/DescriptionTest.py
@@ -62,7 +62,7 @@ class FetchoneDescriptionTest(unittest.TestCase):
                 sqlSelect = "select * from numeric_db"
                 self.cur.execute(sqlSelect)
                 dataDesc = self.cur.description		
-		dataCheck = (('c_int', 8, 0, 0, 10, 0, 0), ('c_short', 9, 0, 0, 5, 0, 0), ('c_numeric', 7, 0, 0, 15, 0, 0), ('c_float', 11, 0, 0, 7, 0, 0), ('c_double', 12, 0, 0, 15, 0, 0), ('c_monetary', 10, 0, 0, 15, 0, 0))
+		dataCheck = (('c_int', 8, 0, 0, 10, 0, 1), ('c_short', 9, 0, 0, 5, 0, 1), ('c_numeric', 7, 0, 0, 15, 0, 1), ('c_float', 11, 0, 0, 7, 0, 1), ('c_double', 12, 0, 0, 15, 0, 1), ('c_monetary', 10, 0, 0, 15, 0, 1))
 		self.assertEquals(dataCheck, dataDesc)
 
         def test_desc_datetime(self):
@@ -70,7 +70,7 @@ class FetchoneDescriptionTest(unittest.TestCase):
                 sqlSelect = "select * from datetime_db"
                 self.cur.execute(sqlSelect)
                 dataDesc = self.cur.description
-                dataCheck = (('c_date', 13, 0, 0, 10, 0, 0), ('c_time', 14, 0, 0, 8, 0, 0), ('c_datetime', 22, 0, 0, 23, 3, 0), ('c_timestamp', 15, 0, 0, 19, 0, 0))
+                dataCheck = (('c_date', 13, 0, 0, 10, 0, 1), ('c_time', 14, 0, 0, 8, 0, 1), ('c_datetime', 22, 0, 0, 23, 3, 1), ('c_timestamp', 15, 0, 0, 19, 0, 1))
 		self.assertEquals(dataCheck, dataDesc)
 
         def test_desc_bit(self):
@@ -78,7 +78,7 @@ class FetchoneDescriptionTest(unittest.TestCase):
                 sqlSelect = "select * from bit_db"
                 self.cur.execute(sqlSelect)
                 dataDesc = self.cur.description
-                dataCheck = (('c_bit', 5, 0, 0, 8, 0, 0), ('c_varbit', 6, 0, 0, 8, 0, 0))
+                dataCheck = (('c_bit', 5, 0, 0, 8, 0, 1), ('c_varbit', 6, 0, 0, 8, 0, 1))
                 self.assertEquals(dataCheck, dataDesc)
 
         def test_desc_char(self):
@@ -86,7 +86,7 @@ class FetchoneDescriptionTest(unittest.TestCase):
                 sqlSelect = "select * from character_db"
                 self.cur.execute(sqlSelect)
                 dataDesc = self.cur.description
-                dataCheck = (('c_char', 1, 0, 0, 4, 0, 0), ('c_varchar', 2, 0, 0, 4, 0, 0), ('c_string', 2, 0, 0, 1073741823, 0, 0), ('c_nchar', 3, 0, 0, 4, 0, 0), ('c_varnchar', 4, 0, 0, 4, 0, 0))
+                dataCheck = (('c_char', 1, 0, 0, 4, 0, 1), ('c_varchar', 2, 0, 0, 4, 0, 1), ('c_string', 2, 0, 0, 1073741823, 0, 1), ('c_nchar', 3, 0, 0, 4, 0, 1), ('c_varnchar', 4, 0, 0, 4, 0, 1))
                 self.assertEquals(dataCheck, dataDesc)
 
         def test_desc_collection(self):
@@ -94,7 +94,7 @@ class FetchoneDescriptionTest(unittest.TestCase):
                 sqlSelect = "select * from collection_db"
                 self.cur.execute(sqlSelect)
                 dataDesc = self.cur.description
-                dataCheck = (('c_set', 32, 0, 0, 0, 0, 0), ('c_multiset', 64, 0, 0, 0, 0, 0), ('c_sequence', 96, 0, 0, 0, 0, 0))
+                dataCheck = (('c_set', 32, 0, 0, 0, 0, 1), ('c_multiset', 64, 0, 0, 0, 0, 1), ('c_sequence', 96, 0, 0, 0, 0, 1))
                 self.assertEquals(dataCheck, dataDesc)
 
 	def test_all(self):

--- a/tests2/python/_07_execute/execute_partition.py
+++ b/tests2/python/_07_execute/execute_partition.py
@@ -23,7 +23,7 @@ class ExecuteNonormalTest(unittest.TestCase):
 		self.cursor= self.conn.cursor()
                 nsql='drop table if exists partition_tb'
                 self.cursor.execute(nsql)
-                nsql2="create table partition_tb(id int not null primary key ,test_char char(50),test_varchar varchar(2000), test_bit bit(16),test_varbit bit varying(20),test_nchar nchar(50),test_nvarchar nchar varying(2000),test_string string,test_datetime timestamp)"
+                nsql2="create table partition_tb(id int not null, test_char char(50),test_varchar varchar(2000), test_bit bit(16),test_varbit bit varying(20),test_nchar nchar(50),test_nvarchar nchar varying(2000),test_string string,test_datetime timestamp, primary key (id, test_char))"
                 self.cursor.execute(nsql2)
 
         def tearDown(self):
@@ -75,7 +75,7 @@ class ExecuteNonormalTest(unittest.TestCase):
                 insertSql2="insert into partition_tb values(5,'ggg','ggg',B'101',B'1111',N'ggg',N'ggg','gggggggggg','2006-03-01 09:00:00')"
                 resultInsert2=self.cursor.execute(insertSql2)
                 self.assertEquals(resultInsert2,1)
-                insertSql3="insert into partition_tb values(10, null,null,null,null,null,null,null,'2007-01-01 09:00:00');"
+                insertSql3="insert into partition_tb values(10, 'kkk',null,null,null,null,null,null,'2007-01-01 09:00:00');"
                 resultInsert3=self.cursor.execute(insertSql3)
                 self.assertEquals(resultInsert3,1)                
 
@@ -98,7 +98,7 @@ class ExecuteNonormalTest(unittest.TestCase):
                 insertSql2="insert into partition_tb values(5,'ggg','ggg',B'101',B'1111',N'ggg',N'ggg','gggggggggg','2006-03-01 09:00:00')"
                 resultInsert2=self.cursor.execute(insertSql2)
                 self.assertEquals(resultInsert2,1)
-                insertSql3="insert into partition_tb values(10, null,null,null,null,null,null,null,'2007-01-01 09:00:00');"
+                insertSql3="insert into partition_tb values(10, 'kkk',null,null,null,null,null,null,'2007-01-01 09:00:00');"
                 resultInsert3=self.cursor.execute(insertSql3)
                 self.assertEquals(resultInsert3,1)
 

--- a/tests2/python/_09_unittest/test_cubrid.py
+++ b/tests2/python/_09_unittest/test_cubrid.py
@@ -166,8 +166,8 @@ class DatabaseTest(unittest.TestCase):
     def test_isolation_level(self):
         con = self._connect()
         try:
-            con.set_isolation_level(CUBRID_REP_CLASS_UNCOMMIT_INSTANCE)
-            self.assertEqual(con.isolation_level, 'CUBRID_REP_CLASS_UNCOMMIT_INSTANCE',
+            con.set_isolation_level(CUBRID_REP_CLASS_COMMIT_INSTANCE)
+            self.assertEqual(con.isolation_level, 'CUBRID_REP_CLASS_COMMIT_INSTANCE',
                     'connection.set_isolation_level does not work')
         finally:
             con.close()
@@ -175,14 +175,14 @@ class DatabaseTest(unittest.TestCase):
     def test_autocommit(self):
         con = self._connect()
         try:
-            self.assertEqual(con.autocommit, 'TRUE',
+            self.assertEqual(con.autocommit, True,
                     'connection.autocommit default is TRUE')
-            con.set_autocommit('ON')
-            self.assertEqual(con.autocommit, 'TRUE',
+            con.set_autocommit(True)
+            self.assertEqual(con.autocommit, True,
                     'connection.autocommit should TURE after set on')
-            con.set_autocommit('OFF')
-            self.assertEqual(con.autocommit, 'FALSE',
-                    'connection.autocommit should TURE after set on')
+            con.set_autocommit(False)
+            self.assertEqual(con.autocommit, False,
+                    'connection.autocommit should FALSE after set on')
         finally:
             con.close()
 

--- a/tests2/runtest.sh
+++ b/tests2/runtest.sh
@@ -11,14 +11,22 @@ MEM_LOG=memoryLeaklog
 FUNC_LOG=function_result
 VALGRIND="valgrind --leak-check=full"
 
-echo "Python DBI Test Begin..."
-
 rm -rf memoryLeaklog
 mkdir  memoryLeaklog
 rm -rf function_result
 mkdir  function_result
 
 PYTHON=$(find_python $*)
+
+python_version_major=$(python_version_check $PYTHON)
+
+if [ x"$python_version_major" != "x2" ];then
+	echo -n "We do not support this version: "
+	$PYTHON --version
+	exit
+fi
+
+echo "Python DBI Test Begin... ($PYTHON)"
 
 cubrid server stop $db
 cubrid createdb $db $CUBRID_LANG
@@ -55,5 +63,6 @@ done
 cubrid server stop $db
 cubrid deletedb $db
 rm -f $testcases
+rm -rf lob
 
 echo "Python DBI Test End"

--- a/tests2/runtest.sh
+++ b/tests2/runtest.sh
@@ -1,51 +1,59 @@
 #!/bin/bash
+. ./init.sh
+
+db=pydb
+CUBRID_LANG=ko_KR.utf8
+PYTHON_CON=configuration/python_config.xml
+#TC_DIR="python performance"
+TC_DIR="python"
+testcases=python_testcase_list
+MEM_LOG=memoryLeaklog
+FUNC_LOG=function_result
+VALGRIND="valgrind --leak-check=full"
+
+echo "Python DBI Test Begin..."
+
 rm -rf memoryLeaklog
 mkdir  memoryLeaklog
 rm -rf function_result
 mkdir  function_result
 
-db=pydb
-cubrid createdb -r $db
-cubrid server start $db
-cubrid broker start
-echo "Python DBI Test Begin..."
-
-brokerPort=`cubrid broker status -b|grep broker1|awk '{print $4}'`
-#a=`cat /etc/sysconfig/network-scripts/ifcfg-eth1|grep IPADDR|awk '{print $1}'`
-a=`/sbin/ifconfig | grep inet | grep -v 127 | awk '{print $2}' | sed 's/addr://g'|sed -n '1p'`
-ipaddress="${a#*=}"
-
-cd ./configuration
-echo "<PythonConfig>" >python_config.xml
-echo "  <ip>localhost</ip>" >> python_config.xml
-echo "  <port>$brokerPort</port>"   >>python_config.xml
-echo "  <dbname>$db</dbname>"  >>python_config.xml
-echo "  <remoteIP>$ipaddress</remoteIP>"  >>python_config.xml
-echo "</PythonConfig>" >>python_config.xml
-cd ..
-
-ls |grep -E "^_" |grep  -v "runTest.sh" | grep -v "CUBRID_Python.list_file" > ./memoryLeaklog/CUBRID_Python.list_file
-while read LIST_FILE
-do
-   cd $LIST_FILE
-   ls |grep -E ".py$" > ./../memoryLeaklog/$LIST_FILE.list
-   
-   while read TEST_FILE
-   do 
-      valgrind --leak-check=full --log-file=./../memoryLeaklog/$TEST_FILE.memoryleak python $TEST_FILE >>./../function_result/$TEST_FILE.result 2>&1
-   done < ./../memoryLeaklog/$LIST_FILE.list
-   
-   cd ..
-
-done < ./memoryLeaklog/CUBRID_Python.list_file
+PYTHON=$(find_python $*)
 
 cubrid server stop $db
-cubrid broker stop
+cubrid createdb $db $CUBRID_LANG
+cubrid server restart $db
+cubrid server restart demodb
+cubrid broker restart
+brokerPort=`cubrid broker status -b|grep broker1|awk '{print $4}'`
+ipaddress=$(hostname -i)
+
+
+echo "<PythonConfig>"			>  $PYTHON_CON
+echo "  <ip>localhost</ip>"		>> $PYTHON_CON
+echo "  <port>$brokerPort</port>"	>> $PYTHON_CON
+echo "  <dbname>$db</dbname>"		>> $PYTHON_CON
+echo "  <remoteIP>$ipaddress</remoteIP>">> $PYTHON_CON
+echo "</PythonConfig>"			>> $PYTHON_CON
+
+# Generate test cases from directories
+rm -f $testcases
+for dir in $TC_DIR
+do
+	find $dir -name '*.py' -print >> $testcases
+done
+
+for tc in $(cat $testcases)
+do
+	tcb=$(basename $tc)
+	echo -n "Running TestCase ($tcb) $tc "
+	$VALGRIND --log-file=$MEM_LOG/$tcb.memLeak $PYTHON $tc >> $FUNC_LOG/$tcb.result 2>&1
+	verdict=$(check_verdict $FUNC_LOG/$tcb.result)
+	echo $verdict
+done
+
+cubrid server stop $db
 cubrid deletedb $db
+rm -f $testcases
 
-rm -rf lob
-rm ./memoryLeaklog/*.list
-rm ./memoryLeaklog/CUBRID_Python.list_file
 echo "Python DBI Test End"
-
-


### PR DESCRIPTION
* Rewrite shell for readability
* could select python to execute in command arguments
* show pass/fail for each group
* could select TestCase Groups to Run (default: test2/python, for changes edit runtest.sh
$ runtest.sh
$ runtest.sh python=/usr/local/bin/python
$ runtest.sh python=/usr/home/python27/bin/python