### PR TITLE
[APIS-830] Patch due to invalid cci submodule reference

### DIFF
--- a/python_cubrid.c
+++ b/python_cubrid.c
@@ -4108,7 +4108,7 @@ PyTypeObject _cubrid_CursorObject_type = {
   0,				/* tp_free */
 };
 
-#define _CUBRID_VERSION_	"10.2.0.0001"
+#define _CUBRID_VERSION_	"10.2.0.0002"
 static char _cubrid_doc[] = "CUBRID API Module for Python";
 
 #if PY_MAJOR_VERSION >= 3

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ if sys.version > '3':
 else:
     setup_file = "setup_2.py"
 
-version = "10.2.0.0001"
+version = "10.2.0.0002"
 
 #os.system(setup_file)
 setup_fh = open(setup_file)

--- a/setup_2.py
+++ b/setup_2.py
@@ -135,7 +135,7 @@ else:
 # Install CUBRID-Python driver.
 setup(
     name="CUBRID-Python",
-    version="10.2.0.0001",
+    version="10.2.0.0002",
     description="Python interface to CUBRID",
     long_description=\
             "Python interface to CUBRID conforming to the python DB API 2.0 "

--- a/setup_3.py
+++ b/setup_3.py
@@ -132,7 +132,7 @@ if sys.version >= '3':
 # Install CUBRID-Python driver.
 setup(
     name="CUBRID-Python",
-    version="10.2.0.0001",
+    version="10.2.0.0002",
     description="Python interface to CUBRID",
     long_description=\
             "Python interface to CUBRID conforming to the python DB API 2.0 "


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-830
* Found invalid reference of regex38a.h in cci submodule.
* Replace cci submodule reference to latest version.