### PR TITLE
[APIS-862] fix build_cci.sh on update configure file

### DIFF
--- a/build_cci.sh
+++ b/build_cci.sh
@@ -8,6 +8,7 @@ fi
 
 cd cci-src
 chmod +x configure
+touch configure.ac
 if [ "$1" = 'x86' ];then
   ./configure 
 else


### PR DESCRIPTION
http://jira.cubrid.org/browse/APIS-862

Purpose
Configure file is not update because 'configure.ac' file’s create date is the same.
Implementation
N/A
Remarks
N/A