### PR TITLE
[CUBVEC-86] Support COPY FROM STDIN (FORMAT BINARY) for VECTOR and primitive types

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "cci-src"]
 	path = cci-src
 	url = https://github.com/CUBRID/cubrid-cci.git
-	branch = develop
+	branch = cubvec/m1

--- a/CUBRIDdb/connections.py
+++ b/CUBRIDdb/connections.py
@@ -7,6 +7,7 @@ override Connection.default_cursor with a non-standard Cursor class.
 """
 from _cubrid import connect as cubrid_connect
 from CUBRIDdb.cursors import *
+from CUBRIDdb.copy import CopyWriter, DEFAULT_BUFFER_SIZE
 
 
 class Connection(object):
@@ -119,4 +120,18 @@ class Connection(object):
         Executes more than one sql statement at the same time.
         """
         return self.connection.batch_execute(sql)
+
+    def copy(self, stmt, types=None, buffer_size=DEFAULT_BUFFER_SIZE):
+        """
+        Start a buffered COPY FROM STDIN (FORMAT BINARY) session.
+
+        Returns a CopyWriter that auto-chunks writes to `buffer_size` bytes
+        per network flush. Use as a context manager or call close() yourself.
+
+        If `types` is given (list of CUBRID column type names in column order),
+        you can call writer.write_row((v1, v2, ...)) with Python values and the
+        driver encodes to the binary wire format. Otherwise, use writer.write()
+        with pre-encoded bytes.
+        """
+        return CopyWriter(self, stmt, types=types, buffer_size=buffer_size)
 

--- a/CUBRIDdb/copy.py
+++ b/CUBRIDdb/copy.py
@@ -1,0 +1,232 @@
+"""
+CUBRIDdb.copy — high-level buffered writer for COPY FROM STDIN (FORMAT BINARY).
+
+Usage:
+
+    # Low-level (caller builds bytes, driver chunks them to the wire):
+    with conn.copy("COPY t FROM STDIN WITH (FORMAT BINARY)") as w:
+        w.write(raw_bytes)
+        w.write(more_raw_bytes)
+    rows_loaded = w.rows_loaded
+
+    # High-level (driver encodes Python tuples):
+    with conn.copy("COPY t FROM STDIN WITH (FORMAT BINARY)",
+                   types=["INT", "VECTOR"]) as w:
+        for id_, vec in iter_rows:
+            w.write_row((id_, vec))
+    rows_loaded = w.rows_loaded
+"""
+
+import struct
+
+
+DEFAULT_BUFFER_SIZE = 1 << 20   # 1 MiB per network flush
+
+
+# ----- wire-format primitives ---------------------------------------------
+
+_NULL_FIELD = struct.pack("!i", -1)
+_FOOTER = struct.pack("!h", -1)
+
+
+def _enc_null():
+    return _NULL_FIELD
+
+
+def _enc_int(v):
+    return struct.pack("!ii", 4, int(v))
+
+
+def _enc_bigint(v):
+    return struct.pack("!i", 8) + struct.pack("!q", int(v))
+
+
+def _enc_float(v):
+    return struct.pack("!i", 4) + struct.pack("!f", float(v))
+
+
+def _enc_double(v):
+    return struct.pack("!i", 8) + struct.pack("!d", float(v))
+
+
+def _enc_varchar(v):
+    b = v.encode("utf-8") if isinstance(v, str) else bytes(v)
+    return struct.pack("!i", len(b)) + b
+
+
+def _enc_vector(v):
+    # v is a sequence of floats
+    body = struct.pack("!i", len(v))
+    for x in v:
+        body += struct.pack("!f", float(x))
+    return struct.pack("!i", len(body)) + body
+
+
+_ENCODERS = {
+    "INT":       _enc_int,
+    "INTEGER":   _enc_int,
+    "BIGINT":    _enc_bigint,
+    "FLOAT":     _enc_float,
+    "REAL":      _enc_float,
+    "DOUBLE":    _enc_double,
+    "VARCHAR":   _enc_varchar,
+    "STRING":    _enc_varchar,
+    "CHAR":      _enc_varchar,
+    "VECTOR":    _enc_vector,
+}
+
+
+def _encoder_for(type_name):
+    key = type_name.upper().strip()
+    # Strip "(n)" / "(n,m)" suffixes so "VARCHAR(64)" → "VARCHAR".
+    paren = key.find("(")
+    if paren != -1:
+        key = key[:paren].rstrip()
+    try:
+        return _ENCODERS[key]
+    except KeyError:
+        raise ValueError(f"CopyWriter: unsupported column type {type_name!r}")
+
+
+# ----- buffered writer ----------------------------------------------------
+
+class CopyWriter:
+    """Buffered writer over `cci_copy_send_data`. Auto-chunks to buffer_size
+    bytes per network flush. Sends the footer on close.
+
+    The writer runs `COPY ... FROM STDIN WITH (FORMAT BINARY)` on construction
+    (via the given cursor) and leaves the connection in an in-progress COPY
+    state until close() — you must close() or use it as a context manager."""
+
+    def __init__(self, connection, stmt, types=None, buffer_size=DEFAULT_BUFFER_SIZE):
+        self._conn = connection
+        # Accumulator for partial data smaller than buffer_size. Pieces larger
+        # than buffer_size are sliced straight from the caller's buffer with
+        # memoryview (zero-copy) so large writes don't pay a staging cost.
+        self._buf = bytearray()
+        self._buffer_size = int(buffer_size)
+        self._closed = False
+        self._rows_loaded = None
+        self._encoders = (
+            [_encoder_for(t) for t in types] if types is not None else None
+        )
+
+        cur = connection.cursor()
+        try:
+            cur.execute(stmt)
+        finally:
+            cur.close()
+
+    # context manager
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if exc_type is not None:
+            # Still need to close the COPY state cleanly. Best effort.
+            try:
+                self.close()
+            except Exception:
+                pass
+            return False
+        self.close()
+        return False
+
+    @property
+    def rows_loaded(self):
+        """Number of rows loaded; available after close()."""
+        return self._rows_loaded
+
+    # --- writing -----------------------------------------------------------
+
+    def write(self, data):
+        """Append already-encoded bytes; flushes in buffer_size chunks.
+
+        Fast path: when the accumulator is empty and `data` is bigger than
+        `buffer_size`, we slice the caller's buffer with memoryview and send
+        each slice directly — no staging copy. Small pieces (from write_row)
+        still accumulate in `self._buf` until it reaches buffer_size."""
+        if self._closed:
+            raise ValueError("CopyWriter is closed")
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise TypeError("write() expects bytes-like object")
+
+        bs = self._buffer_size
+        n = len(data)
+        if n == 0:
+            return
+
+        # Merge with any accumulator first so we keep chunk boundaries aligned.
+        if self._buf:
+            remaining = bs - len(self._buf)
+            if n <= remaining:
+                self._buf.extend(data)
+                if len(self._buf) >= bs:
+                    self._flush()
+                return
+            self._buf.extend(memoryview(data)[:remaining])
+            self._flush()
+            data = memoryview(data)[remaining:]
+            n = len(data)
+
+        # Stream full chunks directly out of the caller's buffer.
+        if n >= bs:
+            mv = data if isinstance(data, memoryview) else memoryview(data)
+            send = self._conn.connection.copy_send_data
+            i = 0
+            while i + bs <= n:
+                send(mv[i:i + bs])
+                i += bs
+            if i < n:
+                self._buf.extend(mv[i:])
+            return
+
+        # Tail smaller than buffer_size — accumulate.
+        self._buf.extend(data)
+
+    def write_row(self, values):
+        """Encode a tuple/list of Python values using the types= given at
+        construction time. Requires types= to be set."""
+        if self._encoders is None:
+            raise ValueError(
+                "write_row() requires types=[...] to be given to CopyWriter"
+            )
+        if len(values) != len(self._encoders):
+            raise ValueError(
+                f"row has {len(values)} values, expected {len(self._encoders)}"
+            )
+        row = bytearray(struct.pack("!h", len(values)))
+        for v, enc in zip(values, self._encoders):
+            row += _NULL_FIELD if v is None else enc(v)
+        self.write(bytes(row))
+
+    def write_rows(self, rows):
+        """Write an iterable of tuples/lists. Convenience wrapper."""
+        for r in rows:
+            self.write_row(r)
+
+    # --- lifecycle ---------------------------------------------------------
+
+    def _flush(self):
+        if self._buf:
+            # bytearray supports the buffer protocol, so copy_send_data (y#)
+            # reads it directly without an extra copy.
+            self._conn.connection.copy_send_data(self._buf)
+            self._buf.clear()
+
+    def close(self):
+        """Flush any buffered bytes, send the footer, call copy_end.
+        Sets self.rows_loaded. Safe to call twice."""
+        if self._closed:
+            return self._rows_loaded
+        self._closed = True
+        try:
+            self._buf.extend(_FOOTER)
+            self._flush()
+            self._rows_loaded = self._conn.connection.copy_end()
+        except Exception:
+            # Do NOT swallow the error — caller needs to see it. But mark closed
+            # to prevent re-entry.
+            self._rows_loaded = None
+            raise
+        return self._rows_loaded

--- a/build_cci.sh
+++ b/build_cci.sh
@@ -20,5 +20,5 @@ elif [ "$1" = 'clean' ];then
   mkdir -p build_x86_64_release
   exit 0
 else
-  sh build.sh
+  bash build.sh
 fi

--- a/cubrid_ext/python_cubrid.c
+++ b/cubrid_ext/python_cubrid.c
@@ -1079,6 +1079,59 @@ _cubrid_ConnectionObject_batch_execute (_cubrid_ConnectionObject * self,
   return p_batch_result;
 }
 
+static char _cubrid_ConnectionObject_copy_send_data__doc__[] = "copy_send_data(data)\n\
+Send binary data for a COPY FROM STDIN operation.\n\
+The data argument must be a bytes object containing the binary payload.\n";
+
+static PyObject *
+_cubrid_ConnectionObject_copy_send_data (_cubrid_ConnectionObject * self,
+					 PyObject * args)
+{
+  Py_buffer buf;
+  int res;
+  T_CCI_ERROR error;
+
+  /* y* accepts any bytes-like object (bytes, bytearray, memoryview) via the
+   * buffer protocol, without an extra copy. Caller must PyBuffer_Release. */
+  if (!PyArg_ParseTuple (args, "y*", &buf))
+    {
+      return NULL;
+    }
+
+  res = cci_copy_send_data (self->handle, (const char *) buf.buf, (int) buf.len, &error);
+  PyBuffer_Release (&buf);
+  if (res < 0)
+    {
+      return handle_error (res, &error);
+    }
+
+  Py_RETURN_NONE;
+}
+
+static char _cubrid_ConnectionObject_copy_end__doc__[] = "copy_end()\n\
+Signal the end of a COPY FROM STDIN operation.\n\
+Returns the number of rows loaded.\n";
+
+static PyObject *
+_cubrid_ConnectionObject_copy_end (_cubrid_ConnectionObject * self,
+				   PyObject * args)
+{
+  int res;
+  T_CCI_ERROR error;
+
+  if (!PyArg_ParseTuple (args, ""))
+    {
+      return NULL;
+    }
+
+  res = cci_copy_end (self->handle, &error);
+  if (res < 0)
+    {
+      return handle_error (res, &error);
+    }
+
+  return _cubrid_return_PyInt_FromLong ((long) res);
+}
 
 static char _cubrid_ConnectionObject_last_insert_id__doc__[] = "insert_id()\n\
 This function returns the value with the IDs generated or the\n\
@@ -4227,6 +4280,16 @@ static PyMethodDef _cubrid_ConnectionObject_methods[] = {
    (PyCFunction) _cubrid_ConnectionObject_batch_execute,
    METH_VARARGS,
    _cubrid_ConnectionObject_batch_execute__doc__},
+  {
+   "copy_send_data",
+   (PyCFunction) _cubrid_ConnectionObject_copy_send_data,
+   METH_VARARGS,
+   _cubrid_ConnectionObject_copy_send_data__doc__},
+  {
+   "copy_end",
+   (PyCFunction) _cubrid_ConnectionObject_copy_end,
+   METH_VARARGS,
+   _cubrid_ConnectionObject_copy_end__doc__},
   {NULL, NULL}
 };
 

--- a/tests3/bench_copy_writer.py
+++ b/tests3/bench_copy_writer.py
@@ -1,0 +1,158 @@
+"""
+Benchmark: CopyWriter (buffered, auto-chunked) vs raw copy_send_data.
+
+Question: does the Python-side buffering layer add perceptible overhead on top
+of raw pass-through?
+
+Both paths produce the same bytes on the wire; only the Python glue differs.
+"""
+
+import os
+import struct
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import CUBRIDdb
+
+
+DIM = 256
+N = 50_000  # ~52 MB of payload
+
+
+def row_bytes(i):
+    hdr = struct.pack("!h", 2)
+    int_f = struct.pack("!i", 4) + struct.pack("!i", i)
+    vec_body = struct.pack("!i", DIM)
+    for k in range(DIM):
+        vec_body += struct.pack("!f", (i + k) * 0.001)
+    vec_f = struct.pack("!i", len(vec_body)) + vec_body
+    return hdr + int_f + vec_f
+
+
+def footer():
+    return struct.pack("!h", -1)
+
+
+def build_all_bytes(n):
+    buf = bytearray()
+    for i in range(n):
+        buf += row_bytes(i)
+    return bytes(buf)
+
+
+def bench_raw_single(conn, cur, payload):
+    """Baseline: one copy_send_data with everything."""
+    cur.execute("DROP TABLE IF EXISTS t_bench")
+    cur.execute(f"CREATE TABLE t_bench (id INT, vec VECTOR({DIM}))")
+    conn.commit()
+
+    t0 = time.perf_counter()
+    cur.execute("COPY t_bench FROM STDIN WITH (FORMAT BINARY)")
+    conn.connection.copy_send_data(payload + footer())
+    loaded = conn.connection.copy_end()
+    conn.commit()
+    return time.perf_counter() - t0, loaded
+
+
+def bench_raw_manual_chunks(conn, cur, payload, chunk):
+    """Baseline: manual chunking, same size as CopyWriter default."""
+    cur.execute("DROP TABLE IF EXISTS t_bench")
+    cur.execute(f"CREATE TABLE t_bench (id INT, vec VECTOR({DIM}))")
+    conn.commit()
+
+    t0 = time.perf_counter()
+    cur.execute("COPY t_bench FROM STDIN WITH (FORMAT BINARY)")
+    for i in range(0, len(payload), chunk):
+        conn.connection.copy_send_data(payload[i:i + chunk])
+    conn.connection.copy_send_data(footer())
+    loaded = conn.connection.copy_end()
+    conn.commit()
+    return time.perf_counter() - t0, loaded
+
+
+def bench_copywriter_bytes(conn, cur, payload, buffer_size):
+    """CopyWriter with pre-encoded bytes via .write()."""
+    cur.execute("DROP TABLE IF EXISTS t_bench")
+    cur.execute(f"CREATE TABLE t_bench (id INT, vec VECTOR({DIM}))")
+    conn.commit()
+
+    t0 = time.perf_counter()
+    with conn.copy(
+        f"COPY t_bench FROM STDIN WITH (FORMAT BINARY)",
+        buffer_size=buffer_size,
+    ) as w:
+        # Feed in same-sized slices as raw_manual_chunks for fair compare
+        # but CopyWriter does its own chunking internally.
+        w.write(payload)
+    conn.commit()
+    return time.perf_counter() - t0, w.rows_loaded
+
+
+def bench_copywriter_rows(conn, cur, n, buffer_size):
+    """CopyWriter with .write_row() — also pays the Python-side encoding cost."""
+    cur.execute("DROP TABLE IF EXISTS t_bench")
+    cur.execute(f"CREATE TABLE t_bench (id INT, vec VECTOR({DIM}))")
+    conn.commit()
+
+    t0 = time.perf_counter()
+    with conn.copy(
+        f"COPY t_bench FROM STDIN WITH (FORMAT BINARY)",
+        types=["INT", "VECTOR"],
+        buffer_size=buffer_size,
+    ) as w:
+        for i in range(n):
+            w.write_row((i, [(i + k) * 0.001 for k in range(DIM)]))
+    conn.commit()
+    return time.perf_counter() - t0, w.rows_loaded
+
+
+def fmt(dt, size, loaded):
+    mbs = size / dt / (1024 * 1024)
+    krows = loaded / dt / 1000
+    return f"{dt:.3f}s  {mbs:6.1f} MB/s  {krows:6.1f} k rows/s"
+
+
+def main():
+    conn = CUBRIDdb.connect("CUBRID:localhost:33091:testdb:::", "dba", "")
+    conn.set_autocommit(False)
+    cur = conn.cursor()
+
+    try:
+        print(f"pre-building {N} rows of (INT, VECTOR({DIM}))...")
+        payload = build_all_bytes(N)
+        size = len(payload) + len(footer())
+        print(f"payload: {size / (1024*1024):.1f} MB\n")
+
+        # Warmup
+        bench_raw_single(conn, cur, payload)
+
+        # Run each 3 times, take best
+        def best(f, *args):
+            return min(f(*args) for _ in range(3))
+
+        dt, loaded = best(bench_raw_single, conn, cur, payload)
+        print(f"[raw   single ]  {fmt(dt, size, loaded)}")
+
+        dt, loaded = best(bench_raw_manual_chunks, conn, cur, payload, 1 << 20)
+        print(f"[raw   1MB chk]  {fmt(dt, size, loaded)}")
+
+        dt, loaded = best(bench_copywriter_bytes, conn, cur, payload, 1 << 20)
+        print(f"[CopyW bytes  ]  {fmt(dt, size, loaded)}")
+
+        dt, loaded = best(bench_copywriter_rows, conn, cur, N, 1 << 20)
+        print(f"[CopyW rows   ]  {fmt(dt, size, loaded)}  (includes py-encoding)")
+
+    finally:
+        try:
+            cur.execute("DROP TABLE IF EXISTS t_bench")
+            conn.commit()
+        except Exception:
+            pass
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests3/test_copy_large_stream.py
+++ b/tests3/test_copy_large_stream.py
@@ -1,0 +1,151 @@
+"""
+Stress test: COPY FROM STDIN (FORMAT BINARY) with (INT, VECTOR(256)) rows.
+
+Per-row size ≈ 1042 bytes (2 header + 8 int + 1032 vector).
+
+Two modes:
+  - "single":  all rows + footer in ONE copy_send_data call
+  - "chunked": split into multiple copy_send_data calls, footer at end
+
+Used to characterize the network/buffer ceiling of one message vs. streaming.
+"""
+
+import os
+import struct
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import CUBRIDdb
+
+
+DIM = 256
+
+
+def row_bytes(i):
+    """Encode one (INT, VECTOR(256)) tuple."""
+    # header
+    hdr = struct.pack("!h", 2)
+    # INT
+    int_f = struct.pack("!i", 4) + struct.pack("!i", i)
+    # VECTOR(256)
+    vec_body = struct.pack("!i", DIM)
+    for k in range(DIM):
+        vec_body += struct.pack("!f", (i + k) * 0.001)
+    vec_f = struct.pack("!i", len(vec_body)) + vec_body
+    return hdr + int_f + vec_f
+
+
+def footer():
+    return struct.pack("!h", -1)
+
+
+def fmt_bytes(n):
+    for unit in ("B", "KB", "MB", "GB"):
+        if n < 1024:
+            return f"{n:.1f}{unit}"
+        n /= 1024
+    return f"{n:.1f}TB"
+
+
+def run_single(conn, cur, n_rows, table):
+    cur.execute(f"DROP TABLE IF EXISTS {table}")
+    cur.execute(f"CREATE TABLE {table} (id INT, vec VECTOR({DIM}))")
+    conn.commit()
+
+    print(f"  building payload: {n_rows} rows ...", flush=True)
+    buf = bytearray()
+    for i in range(n_rows):
+        buf += row_bytes(i)
+    buf += footer()
+    size = len(buf)
+    print(f"  payload size: {fmt_bytes(size)} in ONE copy_send_data call")
+
+    t0 = time.perf_counter()
+    cur.execute(f"COPY {table} FROM STDIN WITH (FORMAT BINARY)")
+    conn.connection.copy_send_data(bytes(buf))
+    loaded = conn.connection.copy_end()
+    conn.commit()
+    dt = time.perf_counter() - t0
+
+    assert loaded == n_rows, f"expected {n_rows}, got {loaded}"
+    mbs = size / dt / (1024 * 1024)
+    print(f"  loaded {loaded} rows in {dt:.2f}s ({mbs:.1f} MB/s) — OK")
+    return size, dt
+
+
+def run_chunked(conn, cur, n_rows, rows_per_send, table):
+    cur.execute(f"DROP TABLE IF EXISTS {table}")
+    cur.execute(f"CREATE TABLE {table} (id INT, vec VECTOR({DIM}))")
+    conn.commit()
+
+    # Pre-encode for a cleaner timing
+    chunks = []
+    buf = bytearray()
+    for i in range(n_rows):
+        buf += row_bytes(i)
+        if (i + 1) % rows_per_send == 0:
+            chunks.append(bytes(buf))
+            buf = bytearray()
+    if buf:
+        chunks.append(bytes(buf))
+    chunks.append(footer())
+    total = sum(len(c) for c in chunks)
+    print(f"  chunked: {n_rows} rows → {len(chunks)} send_data calls, total {fmt_bytes(total)}")
+
+    t0 = time.perf_counter()
+    cur.execute(f"COPY {table} FROM STDIN WITH (FORMAT BINARY)")
+    for c in chunks:
+        conn.connection.copy_send_data(c)
+    loaded = conn.connection.copy_end()
+    conn.commit()
+    dt = time.perf_counter() - t0
+
+    assert loaded == n_rows, f"expected {n_rows}, got {loaded}"
+    mbs = total / dt / (1024 * 1024)
+    print(f"  loaded {loaded} rows in {dt:.2f}s ({mbs:.1f} MB/s) — OK")
+
+
+def main():
+    dsn = "CUBRID:localhost:33091:testdb:::"
+    conn = CUBRIDdb.connect(dsn, "dba", "")
+    conn.set_autocommit(False)
+    cur = conn.cursor()
+
+    try:
+        # Single-shot scaling — find ceiling of one copy_send_data call
+        for n in (1_000, 10_000, 50_000):
+            print(f"\n[single] n={n}")
+            try:
+                run_single(conn, cur, n, "t_big_single")
+            except Exception as e:
+                print(f"  FAILED at n={n}: {type(e).__name__}: {e}")
+                # rollback & reconnect so subsequent tests don't see a dead tx
+                try:
+                    conn.rollback()
+                except Exception:
+                    pass
+                break
+
+        # Chunked streaming — arbitrarily large totals are fine if chunks are safe
+        print(f"\n[chunked] 100_000 rows, 1_000 rows/send")
+        try:
+            run_chunked(conn, cur, 100_000, 1_000, "t_big_chunked")
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+
+        print("\nDone.")
+    finally:
+        for t in ("t_big_single", "t_big_chunked"):
+            try:
+                cur.execute(f"DROP TABLE IF EXISTS {t}")
+                conn.commit()
+            except Exception:
+                pass
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests3/test_copy_rollback.py
+++ b/tests3/test_copy_rollback.py
@@ -1,0 +1,139 @@
+"""
+Correctness scenarios for COPY FROM STDIN (FORMAT BINARY) with (INT, VECTOR(256)),
+exercising the skip_inner_sysop path in file_alloc.
+
+Notes on semantics (important):
+  - COPY FROM STDIN uses the BU_LOCK bulk-insert path. With bulk logging in
+    effect, inserted rows are NOT rolled back by a transaction ROLLBACK — same
+    property as other databases' bulk-load fast paths. Tests therefore assert
+    commit-visibility only, and do not assume rollback undoes the rows.
+  - The outer atomic sysop in copy_session::flush_batch guarantees file-header
+    consistency on crash recovery; that property is verified separately via
+    the FI_TEST_FILE_PERM_EXPAND_AFTER_COMMIT fault injection (manual test),
+    not here.
+
+Scenarios:
+  1. Small batch (commit): <1 heap page.
+  2. Large batch (commit): thousands of rows, forces many file_alloc calls and
+     at least one file_perm_expand, exercising skip_inner_sysop + atomic outer.
+  3. Successive COPY in the same transaction: each batch must remain visible
+     after its own commit and to subsequent SELECTs in the same session.
+"""
+
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import CUBRIDdb
+
+
+DIM = 256
+SMALL_ROWS = 5
+LARGE_ROWS = 10_000
+TABLE = "t_copy_skip_sysop"
+
+
+def _row_bytes(i):
+    hdr = struct.pack("!h", 2)
+    int_f = struct.pack("!i", 4) + struct.pack("!i", i)
+    vec_body = (struct.pack("!i", DIM)
+                + struct.pack(f"<{DIM}f", *((i + k) * 0.001 for k in range(DIM))))
+    vec_f = struct.pack("!i", len(vec_body)) + vec_body
+    return hdr + int_f + vec_f
+
+
+def _build_payload(start, n):
+    buf = bytearray()
+    for i in range(start, start + n):
+        buf += _row_bytes(i)
+    buf += struct.pack("!h", -1)
+    return bytes(buf)
+
+
+def _run_copy(conn, cur, payload):
+    cur.execute(f"COPY {TABLE} FROM STDIN WITH (FORMAT BINARY)")
+    conn.connection.copy_send_data(payload)
+    return conn.connection.copy_end()
+
+
+def _count(cur):
+    cur.execute(f"SELECT COUNT(*) FROM {TABLE}")
+    return cur.fetchone()[0]
+
+
+def _min_max(cur):
+    cur.execute(f"SELECT MIN(id), MAX(id) FROM {TABLE}")
+    return cur.fetchone()
+
+
+def main():
+    dsn = "CUBRID:localhost:33000:testdb:::"
+    conn = CUBRIDdb.connect(dsn, "dba", "")
+    conn.set_autocommit(False)
+    cur = conn.cursor()
+
+    try:
+        cur.execute(f"DROP TABLE IF EXISTS {TABLE}")
+        cur.execute(f"CREATE TABLE {TABLE} (id INT, vec VECTOR({DIM}))")
+        conn.commit()
+
+        # --- Scenario 1: small batch (commit) ---
+        print(f"[1/3] small batch: COPY {SMALL_ROWS} rows + commit")
+        loaded = _run_copy(conn, cur, _build_payload(0, SMALL_ROWS))
+        assert loaded == SMALL_ROWS, f"loaded {loaded}, expected {SMALL_ROWS}"
+        conn.commit()
+        n = _count(cur)
+        assert n == SMALL_ROWS, f"count after small commit: got {n}"
+        lo, hi = _min_max(cur)
+        assert (lo, hi) == (0, SMALL_ROWS - 1), f"id range: got ({lo},{hi})"
+        conn.commit()
+
+        # Clear for the next scenario (DDL flushes bulk-inserted rows cleanly).
+        cur.execute(f"DROP TABLE {TABLE}")
+        cur.execute(f"CREATE TABLE {TABLE} (id INT, vec VECTOR({DIM}))")
+        conn.commit()
+
+        # --- Scenario 2: large batch (commit) — exercises file_perm_expand ---
+        print(f"[2/3] large batch: COPY {LARGE_ROWS} rows + commit")
+        loaded = _run_copy(conn, cur, _build_payload(0, LARGE_ROWS))
+        assert loaded == LARGE_ROWS, f"loaded {loaded}, expected {LARGE_ROWS}"
+        conn.commit()
+        n = _count(cur)
+        assert n == LARGE_ROWS, f"count after large commit: got {n}"
+        lo, hi = _min_max(cur)
+        assert (lo, hi) == (0, LARGE_ROWS - 1), f"id range: got ({lo},{hi})"
+        conn.commit()
+
+        cur.execute(f"DROP TABLE {TABLE}")
+        cur.execute(f"CREATE TABLE {TABLE} (id INT, vec VECTOR({DIM}))")
+        conn.commit()
+
+        # --- Scenario 3: two successive COPY batches in one session ---
+        print(f"[3/3] successive batches: 2 × COPY {SMALL_ROWS} rows")
+        loaded = _run_copy(conn, cur, _build_payload(0, SMALL_ROWS))
+        assert loaded == SMALL_ROWS, f"first batch loaded {loaded}"
+        conn.commit()
+        loaded = _run_copy(conn, cur, _build_payload(SMALL_ROWS, SMALL_ROWS))
+        assert loaded == SMALL_ROWS, f"second batch loaded {loaded}"
+        conn.commit()
+        n = _count(cur)
+        assert n == 2 * SMALL_ROWS, f"count after two batches: got {n}"
+        lo, hi = _min_max(cur)
+        assert (lo, hi) == (0, 2 * SMALL_ROWS - 1), f"id range: got ({lo},{hi})"
+        conn.commit()
+
+        print("\nAll COPY skip_inner_sysop scenarios passed.")
+    finally:
+        try:
+            cur.execute(f"DROP TABLE IF EXISTS {TABLE}")
+            conn.commit()
+        except Exception:
+            pass
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests3/test_copy_types_batch.py
+++ b/tests3/test_copy_types_batch.py
@@ -1,0 +1,164 @@
+"""
+End-to-end test: COPY FROM STDIN (FORMAT BINARY) — broad type coverage +
+batching confirmation (many tuples in a single copy_send_data call).
+
+Requires a running CUBRID server with a database named 'testdb'.
+"""
+
+import struct
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import CUBRIDdb
+
+
+# --- binary encoders for supported types ---
+
+NULL_LEN = struct.pack("!i", -1)
+
+
+def enc_null():
+    return NULL_LEN
+
+
+def enc_int(v):
+    return struct.pack("!i", 4) + struct.pack("!i", v)
+
+
+def enc_bigint(v):
+    return struct.pack("!i", 8) + struct.pack("!q", v)
+
+
+def enc_float(v):
+    return struct.pack("!i", 4) + struct.pack("!f", v)
+
+
+def enc_double(v):
+    return struct.pack("!i", 8) + struct.pack("!d", v)
+
+
+def enc_varchar(s):
+    b = s.encode("utf-8")
+    return struct.pack("!i", len(b)) + b
+
+
+def enc_vector(xs):
+    body = struct.pack("!i", len(xs))
+    for x in xs:
+        body += struct.pack("!f", x)
+    return struct.pack("!i", len(body)) + body
+
+
+def row_header(num_fields):
+    return struct.pack("!h", num_fields)
+
+
+def footer():
+    return struct.pack("!h", -1)
+
+
+def run(cur, conn, stmt, rows_bytes):
+    """Execute COPY, send rows_bytes+footer in one send_data (one round-trip), end."""
+    cur.execute(stmt)
+    conn.connection.copy_send_data(rows_bytes + footer())
+    return conn.connection.copy_end()
+
+
+def test_all_types_one_row(conn, cur):
+    print("[types] create t_types ...")
+    cur.execute("DROP TABLE IF EXISTS t_types")
+    cur.execute(
+        "CREATE TABLE t_types ("
+        "i INT, bi BIGINT, f FLOAT, d DOUBLE, "
+        "s VARCHAR(64), v VECTOR(3), n INT"
+        ")"
+    )
+    conn.commit()
+
+    # One row with each supported type + a NULL in the last column
+    payload = (
+        row_header(7)
+        + enc_int(42)
+        + enc_bigint(9_000_000_000)
+        + enc_float(1.5)
+        + enc_double(2.71828)
+        + enc_varchar("hello COPY")
+        + enc_vector([0.25, -0.5, 1.125])
+        + enc_null()
+    )
+
+    loaded = run(cur, conn, "COPY t_types FROM STDIN WITH (FORMAT BINARY)", payload)
+    conn.commit()
+    assert loaded == 1, f"expected 1 row loaded, got {loaded}"
+
+    cur.execute("SELECT i, bi, f, d, s, CAST(v AS STRING), n FROM t_types")
+    row = cur.fetchone()
+    print(f"  got: {row}")
+    assert row[0] == 42
+    assert row[1] == 9_000_000_000
+    assert abs(row[2] - 1.5) < 1e-5
+    assert abs(row[3] - 2.71828) < 1e-9
+    assert row[4] == "hello COPY"
+    parsed = [float(x) for x in row[5].strip("[]").split(",")]
+    assert len(parsed) == 3 and abs(parsed[0] - 0.25) < 1e-5
+    assert row[6] is None
+    print("[types] OK")
+
+
+def test_batch_many_tuples(conn, cur):
+    print("[batch] create t_batch ...")
+    cur.execute("DROP TABLE IF EXISTS t_batch")
+    cur.execute("CREATE TABLE t_batch (id INT, vec VECTOR(4))")
+    conn.commit()
+
+    N = 500
+    buf = bytearray()
+    for i in range(N):
+        buf += row_header(2)
+        buf += enc_int(i)
+        buf += enc_vector([float(i), float(i) + 0.5, -float(i), 0.0])
+
+    # Single copy_send_data call carrying 500 tuples → one round-trip
+    loaded = run(cur, conn, "COPY t_batch FROM STDIN WITH (FORMAT BINARY)", bytes(buf))
+    conn.commit()
+    assert loaded == N, f"expected {N} rows loaded, got {loaded}"
+
+    cur.execute("SELECT COUNT(*) FROM t_batch")
+    n = cur.fetchone()[0]
+    assert n == N, f"SELECT COUNT(*) got {n}"
+
+    cur.execute("SELECT id, CAST(vec AS STRING) FROM t_batch ORDER BY id LIMIT 3")
+    for i, (got_id, vec_str) in enumerate(cur.fetchall()):
+        assert got_id == i
+        floats = [float(x) for x in vec_str.strip("[]").split(",")]
+        assert abs(floats[0] - i) < 1e-5
+        assert abs(floats[1] - (i + 0.5)) < 1e-5
+        print(f"  row {i}: id={got_id}, vec={vec_str}")
+    print(f"[batch] {N} tuples in one send_data — OK")
+
+
+def main():
+    dsn = "CUBRID:localhost:33091:testdb:::"
+    conn = CUBRIDdb.connect(dsn, "dba", "")
+    conn.set_autocommit(False)
+    cur = conn.cursor()
+
+    try:
+        test_all_types_one_row(conn, cur)
+        test_batch_many_tuples(conn, cur)
+        print("\nAll COPY type + batch tests passed!")
+    finally:
+        try:
+            cur.execute("DROP TABLE IF EXISTS t_types")
+            cur.execute("DROP TABLE IF EXISTS t_batch")
+            conn.commit()
+        except Exception:
+            pass
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests3/test_copy_vector.py
+++ b/tests3/test_copy_vector.py
@@ -1,0 +1,135 @@
+"""
+End-to-end test: COPY FROM STDIN (FORMAT BINARY) with VECTOR type.
+
+Requires a running CUBRID server with a database named 'testdb'.
+
+Usage:
+  python test_copy_vector.py
+"""
+
+import struct
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import _cubrid
+import CUBRIDdb
+
+
+def build_binary_copy_payload(rows):
+    """
+    Build a COPY binary payload for table (id INT, vec VECTOR(3)).
+
+    Each row is (int_val, [float, float, float]).
+    Wire format per row:
+      int16  num_fields
+      For each field:
+        int32  field_len  (-1 for NULL)
+        bytes  field_data
+    Footer: int16 -1
+    """
+    buf = bytearray()
+
+    for int_val, floats in rows:
+        num_fields = 2
+        buf += struct.pack('!h', num_fields)
+
+        # Field 1: INT (4 bytes, network byte order)
+        buf += struct.pack('!i', 4)
+        buf += struct.pack('!i', int_val)
+
+        # Field 2: VECTOR (int32 dim + dim * float32)
+        dim = len(floats)
+        vec_data = struct.pack('!i', dim)
+        for f in floats:
+            vec_data += struct.pack('!f', f)
+        buf += struct.pack('!i', len(vec_data))
+        buf += vec_data
+
+    # Footer sentinel
+    buf += struct.pack('!h', -1)
+
+    return bytes(buf)
+
+
+def main():
+    dsn = "CUBRID:localhost:33091:testdb:::"
+    user = "dba"
+    passwd = ""
+
+    print("Connecting to CUBRID...")
+    conn = CUBRIDdb.connect(dsn, user, passwd)
+    conn.set_autocommit(False)
+    cur = conn.cursor()
+
+    # Setup: create table
+    print("Creating table...")
+    try:
+        cur.execute("DROP TABLE IF EXISTS t_copy_vec")
+    except Exception:
+        pass
+    cur.execute("CREATE TABLE t_copy_vec (id INT, vec VECTOR(3))")
+    conn.commit()
+
+    # Execute COPY statement
+    print("Executing COPY FROM STDIN...")
+    cur.execute("COPY t_copy_vec FROM STDIN WITH (FORMAT BINARY)")
+
+    # Build binary payload with 3 rows
+    rows = [
+        (1, [1.0, 2.5, -3.75]),
+        (2, [0.0, 0.0, 0.0]),
+        (3, [1.5, -2.25, 3.125]),
+    ]
+    payload = build_binary_copy_payload(rows)
+
+    print(f"Sending {len(payload)} bytes of binary data...")
+    conn.connection.copy_send_data(payload)
+
+    print("Ending COPY...")
+    result = conn.connection.copy_end()
+    print(f"Rows loaded: {result}")
+
+    conn.commit()
+
+    # Verify INT column via Python driver (VECTOR fetch not yet supported by _cubrid)
+    print("Verifying INT column via Python driver...")
+    cur.execute("SELECT id FROM t_copy_vec ORDER BY id")
+    fetched = cur.fetchall()
+
+    assert len(fetched) == 3, f"Expected 3 rows, got {len(fetched)}"
+    for i, (expected_id, _) in enumerate(rows):
+        row = fetched[i]
+        assert row[0] == expected_id, f"Row {i+1} id: expected {expected_id}, got {row[0]}"
+        print(f"  Row {i+1}: id={row[0]}")
+
+    # Verify VECTOR column via CAST to STRING (Python _cubrid can't fetch VECTOR directly)
+    print("Verifying VECTOR column via CAST to STRING...")
+    cur.execute("SELECT id, CAST(vec AS STRING) FROM t_copy_vec ORDER BY id")
+    fetched = cur.fetchall()
+    for i, (expected_id, expected_vec) in enumerate(rows):
+        row = fetched[i]
+        vec_str = row[1]
+        print(f"  Row {i+1}: id={row[0]}, vec={vec_str}")
+        assert vec_str is not None, f"Row {i+1} vec is None"
+        # Parse the stringified vector like "[1, 2.5, -3.75]" and compare as floats
+        parsed = [float(x) for x in vec_str.strip("[]").split(",")]
+        assert len(parsed) == len(expected_vec), \
+            f"Row {i+1}: expected {len(expected_vec)} dims, got {len(parsed)}"
+        for j, (got, want) in enumerate(zip(parsed, expected_vec)):
+            assert abs(got - want) < 1e-5, \
+                f"Row {i+1} dim {j}: expected {want}, got {got}"
+
+    # Cleanup
+    cur.execute("DROP TABLE t_copy_vec")
+    conn.commit()
+
+    cur.close()
+    conn.close()
+
+    print("\nAll COPY VECTOR tests passed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests3/test_copy_vector_bench.py
+++ b/tests3/test_copy_vector_bench.py
@@ -1,0 +1,89 @@
+"""
+Benchmark: COPY FROM STDIN (FORMAT BINARY) with 290k rows of (INT, VECTOR(256)).
+
+Mirrors the annb workload so we can measure where time goes inside copy_session.
+"""
+
+import os
+import random
+import struct
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import CUBRIDdb  # noqa: E402
+
+
+NUM_ROWS = 290_000
+VEC_DIM = 256
+CHUNK_ROWS = 4096  # flush_batch size inside copy_session
+
+
+def row_bytes(row_id: int, floats: list[float]) -> bytes:
+    # int16 num_fields=2
+    out = struct.pack('!h', 2)
+    # field 1: INT (4 bytes BE)
+    out += struct.pack('!i', 4) + struct.pack('!i', row_id)
+    # field 2: VECTOR (int32 BE dim + dim*LE float32)
+    vec_data = struct.pack('!i', len(floats)) + struct.pack(f'<{len(floats)}f', *floats)
+    out += struct.pack('!i', len(vec_data)) + vec_data
+    return out
+
+
+def main():
+    random.seed(42)
+    dsn = "CUBRID:localhost:33000:testdb:::"
+    conn = CUBRIDdb.connect(dsn, "dba", "")
+    conn.set_autocommit(False)
+    cur = conn.cursor()
+
+    try:
+        cur.execute("DROP TABLE IF EXISTS t_copy_bench")
+    except Exception:
+        pass
+    cur.execute(f"CREATE TABLE t_copy_bench (id INT, vec VECTOR({VEC_DIM}))")
+    conn.commit()
+
+    print(f"Generating {NUM_ROWS} rows × VECTOR({VEC_DIM})...")
+    t_gen_start = time.time()
+    # Pre-generate in chunks to avoid holding all payload in memory at once.
+    chunks: list[bytes] = []
+    buf = bytearray()
+    for i in range(NUM_ROWS):
+        floats = [random.random() * 2.0 - 1.0 for _ in range(VEC_DIM)]
+        buf += row_bytes(i, floats)
+        if (i + 1) % CHUNK_ROWS == 0:
+            chunks.append(bytes(buf))
+            buf = bytearray()
+    if buf:
+        chunks.append(bytes(buf))
+    # Footer sentinel
+    footer = struct.pack('!h', -1)
+    t_gen = time.time() - t_gen_start
+    total_bytes = sum(len(c) for c in chunks) + len(footer)
+    print(f"  generated in {t_gen:.2f}s, total payload {total_bytes/1e6:.1f} MB")
+
+    print("Executing COPY FROM STDIN...")
+    cur.execute("COPY t_copy_bench FROM STDIN WITH (FORMAT BINARY)")
+
+    t_send_start = time.time()
+    for c in chunks:
+        conn.connection.copy_send_data(c)
+    conn.connection.copy_send_data(footer)
+    rows_loaded = conn.connection.copy_end()
+    t_send = time.time() - t_send_start
+    print(f"Rows loaded: {rows_loaded} in {t_send:.3f}s "
+          f"({rows_loaded/t_send:.0f} rows/s, {total_bytes/t_send/1e6:.1f} MB/s)")
+
+    conn.commit()
+
+    cur.execute("DROP TABLE t_copy_bench")
+    conn.commit()
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
http://jira.cubrid.org/browse/CUBVEC-86

support copy() for a buffered COPY FROM STDIN (FORMAT BINARY) session.

cci: https://github.com/CUBRID/cubrid-cci/pull/104